### PR TITLE
Add specific sudo command options to deploy users

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Dependencies
 ------------
 
 * RHEL 9 server that has been joined to UMN Active Directory
-* Ansible POSIX collection (https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
+* Ansible POSIX galaxy collection (https://docs.ansible.com/ansible/latest/collections/ansible/posix/index.html)
+* Community General galaxy collection (https://docs.ansible.com/ansible/latest/collections/community/general/)
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ umn_user_management_deploy_users:
     # List of any additional ssh keys needed by this user
     # One key per list item
     additional_authorized_keys: []
+    # A list of commands this user may run via sudo
+    sudoers_commands: []
+      # examples (must be full path to executable):
+      #- /usr/bin/ls /opt
+      #- /usr/bin/chown * /opt/*
+      #- /usr/sbin/systemctl * nginx
 ```
 
 ### `umn_user_management_service_users`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,8 +34,10 @@ umn_user_management_deploy_users:
     # Should all ssh keys defined for directory users be added for
     # deploy access via ssh?
     authorized_keys_from_directory_users: yes
-    # Array of any additional ssh keys needed by this user
+    # List of any additional ssh keys needed by this user
     additional_authorized_keys: []
+    # List of sudo rules allowed for this user
+    sudoers_commands: []
 
 umn_user_management_service_users:
   - name: umnapps

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,3 +21,4 @@ galaxy_info:
 
 collections:
   - ansible.posix
+  - community.general

--- a/tasks/deploy_service_users.yml
+++ b/tasks/deploy_service_users.yml
@@ -105,3 +105,25 @@
     index_var: stat_idx
   tags:
     - usermanagement
+
+- name: usermanagement - sudoers rules for deploy users
+  community.general.sudoers:
+    name: ansible-sudoers-deploy-{{ item.name }}
+    state: present
+    user: '{{ item.name }}'
+    commands: '{{ item.sudoers_commands }}'
+    nopassword: true
+  loop: '{{ umn_user_management_deploy_users }}'
+  when: item.sudoers_commands != None and item.sudoers_commands|length > 0
+  tags:
+    - usermanagement
+    - sudoers
+
+# Ensure no orphaned sudoers files are left if the previous command isn't run
+- name: usermanagement - sudoers purge unused files
+  community.general.sudoers:
+    name: ansible-sudoers-deploy-{{ item.name }}
+    state: absent
+  loop: '{{ umn_user_management_deploy_users }}'
+  # Do this for deploy users without sudo defined
+  when: item.sudoers_commands == None or item.sudoers_commands|length == 0

--- a/tasks/directory_user_setup.yml
+++ b/tasks/directory_user_setup.yml
@@ -33,22 +33,45 @@
   tags:
     - usermanagement
 
-- name: usermanagement - Create sudoers files for directory users and groups
-  ansible.builtin.template:
-    src: templates/sudoers-ad-entities
-    dest: /etc/sudoers.d/ansible-sudoers-ad-{{ item.entitytype }}
-    validate: /usr/sbin/visudo --check --file=%s
-    owner: root
-    group: root
-    mode: '0600'
-  loop:
-    - entitytype: users
-      sudoers_ad_entities: '{{ umn_user_management_permitted_users }}'
-    - entitytype: groups
-      sudoers_ad_entities: '{{ umn_user_management_permitted_groups }}'
+- name: usermanagement - Create sudoers files for directory users
+  community.general.sudoers:
+    name: ansible-sudoers-ad-user-{{ item.name }}
+    user: '{{ item.name }}'
+    validation: required
+    commands: ALL
+    nopassword: true
+  loop: '{{ umn_user_management_permitted_users }}'
+  when: (item.sudo|default(False)) == True and (item.revoke|default(False)) == False
   tags:
     - usermanagement
     - sudoers
+
+- name: usermanagement - Create sudoers files for directory groups
+  community.general.sudoers:
+    name: ansible-sudoers-ad-group-{{ item.name }}
+    group: '{{ item.name }}'
+    validation: required
+    commands: ALL
+    nopassword: true
+  loop: '{{ umn_user_management_permitted_groups }}'
+  when: (item.sudo|default(False)) == True and (item.revoke|default(False)) == False
+  tags:
+    - usermanagement
+    - sudoers
+
+- name: usermanagement - Remove sudoers privileges for revoked or non-sudo users
+  community.general.sudoers:
+    name: ansible-sudoers-ad-user-{{ item.name }}
+    state: absent
+  loop: '{{ umn_user_management_directory_users }}'
+  when: (item.sudo|default(False)) == False or (item.revoke|default(False)) == True
+
+- name: usermanagement - Remove sudoers privileges for revoked or non-sudo groups
+  community.general.sudoers:
+    name: ansible-sudoers-ad-group-{{ item.name }}
+    state: absent
+  loop: '{{ umn_user_management_directory_groups }}'
+  when: (item.sudo|default(False)) == False or (item.revoke|default(False)) == True
 
 - name: usermanagement - Install SSH keys for directory users
   ansible.posix.authorized_key:

--- a/tasks/directory_user_setup.yml
+++ b/tasks/directory_user_setup.yml
@@ -37,7 +37,7 @@
   ansible.builtin.template:
     src: templates/sudoers-ad-entities
     dest: /etc/sudoers.d/ansible-sudoers-ad-{{ item.entitytype }}
-    validate: /usr/sbin/visudo -cf %s
+    validate: /usr/sbin/visudo --check --file=%s
     owner: root
     group: root
     mode: '0600'

--- a/templates/sudoers-ad-entities
+++ b/templates/sudoers-ad-entities
@@ -1,7 +1,0 @@
-# FILE MANAGED BY ANSIBLE - DO NOT MODIFY
-{% for ad_entity in item.sudoers_ad_entities %}
-{%- if ad_entity.sudo|default(False) == True and ad_entity.revoke|default(False) == False %}
-{%- if item.entitytype == 'groups' %}%{% endif %}{{ ad_entity.name }} ALL=(ALL) NOPASSWD: ALL
-{% endif %}
-{% endfor %}
-


### PR DESCRIPTION
Fixes #2 by adding a `sudoers_commands:` property to deploy users (default empty). Makes use of galaxy `community.general.sudoers` since that is better at handling specific command privileges than the templating method already in use.

And since we now have a community.general galaxy dependency, the existing sudoers task for AD users & groups is refactored to use `community.general.sudoers` instead.

Note: If you already ran a playbook with `sudo: yes` on AD users or groups, this change will result in redundant files at `/etc/sudoers.d/ansible-sudoers-ad-{users,groups}`. Henceforth, the role will create individual sudoers files for each user and group e.g.  `/etc/sudoers.d/ansible-sudoers-ad-user-mjb`