### PR TITLE
Explicit cron support for human and deploy/service users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ umn_user_management_directory_users:
     revoke: yes|no
     # Creates a user entry in a file in /etc/sudoers.d
     sudo: yes|no
+    allow_cron: yes|no
     authorized_keys:
       - 'ssh-rsa.....'
       - 'ssh-ed25519.....'
@@ -77,6 +78,8 @@ umn_user_management_deploy_users:
     groups: []
     shell: /bin/bash
     create_home: yes
+    # Permit the user to have a crontab (denied by default by the system)
+    allow_cron: no
     # Should all ssh keys defined for directory users be added for
     # deploy access via ssh? Any individual user from umn_user_management_directory_users
     # will have their ssh private keys installed for use with this user

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ umn_user_management_directory_users: []
 #     revoke: yes|no
 #     # Creates a user entry in a file in /etc/sudoers.d
 #     sudo: yes|no
+#     allow_cron: yes|no (default no)
 #     authorized_keys:
 #       - 'ssh-key1.....'
 #       - 'ssh-key2.....'
@@ -31,6 +32,7 @@ umn_user_management_deploy_users:
     groups: []
     shell: /bin/bash
     create_home: yes
+    allow_cron: no
     # Should all ssh keys defined for directory users be added for
     # deploy access via ssh?
     authorized_keys_from_directory_users: yes
@@ -47,6 +49,7 @@ umn_user_management_service_users:
     groups: []
     shell: /bin/false
     create_home: no
+    allow_cron: no
 # umn_user_management_service_users:
 #   - username: serviceuser
 #     uid: 12345

--- a/tasks/deploy_service_users.yml
+++ b/tasks/deploy_service_users.yml
@@ -127,3 +127,17 @@
   loop: '{{ umn_user_management_deploy_users }}'
   # Do this for deploy users without sudo defined
   when: item.sudoers_commands is undefined or item.sudoers_commands|length == 0
+  tags:
+    - usermanagement
+    - sudoers
+
+# Enable/disable cron users
+- name: usermanagement - permit cron users
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: '{{ item.name }}'
+    state: '{{ "present" if (item.allow_cron|default(false)) else "absent" }}'
+  loop: '{{ umn_user_management_deploy_users + umn_user_management_service_users }}'
+  tags:
+    - usermanagement
+    - cron

--- a/tasks/deploy_service_users.yml
+++ b/tasks/deploy_service_users.yml
@@ -136,7 +136,7 @@
   ansible.builtin.lineinfile:
     path: /etc/cron.allow
     line: '{{ item.name }}'
-    state: '{{ "present" if (item.allow_cron|default(false)) else "absent" }}'
+    state: '{{ "present" if (item.allow_cron|default(False)) else "absent" }}'
   loop: '{{ umn_user_management_deploy_users + umn_user_management_service_users }}'
   tags:
     - usermanagement

--- a/tasks/directory_user_setup.yml
+++ b/tasks/directory_user_setup.yml
@@ -85,3 +85,14 @@
   loop: '{{ umn_user_management_permitted_users }}'
   tags:
     - usermanagement
+
+# Enable/disable cron users
+- name: usermanagement - permit cron for directory users
+  ansible.builtin.lineinfile:
+    path: /etc/cron.allow
+    line: '{{ item.name }}'
+    state: '{{ "present" if (item.allow_cron|default(False)) else "absent" }}'
+  loop: '{{ umn_user_management_directory_users }}'
+  tags:
+    - usermanagement
+    - cron


### PR DESCRIPTION
Platform requires users be explicitly added to /etc/cron.allow to enable crontabs. 

This adds a default false `allow_cron:` option on all human (directory) and service/deploy users which will list them in cron.allow or remove them.